### PR TITLE
Fix type comparison in isOwner middleware to ensure proper access con…

### DIFF
--- a/backend/middlewares/authRole.js
+++ b/backend/middlewares/authRole.js
@@ -37,7 +37,7 @@ exports.isAdmin = (req, res, next) => {
 
 // Middleware to check if the user is the owner of the resource
 exports.isOwner = (req, res, next) => {
-  if (req.user.id !== req.params.id) {
+  if (req.user.id !== parseInt(req.params.id)) {
     return res.status(403).json({ message: "Access Denied! Unauthorized" });
   }
 


### PR DESCRIPTION
This pull request includes a small but important change to the `isOwner` middleware function in the `backend/middlewares/authRole.js` file. The change ensures that the comparison between `req.user.id` and `req.params.id` is accurate by parsing `req.params.id` as an integer.

* [`backend/middlewares/authRole.js`](diffhunk://#diff-62e7188c6fd96a1d02bbfba7db2ae41ca7533b96ea2fe4800943a8ad15990421L40-R40): Modified the `isOwner` function to parse `req.params.id` as an integer before comparing it to `req.user.id`.